### PR TITLE
Adding slot to a-select for changing select head

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # Ant Design Vue 
 by Mottor 💪
+
+# Основные изменения по сравнению с оригинальным Ant Design Vue 
+
+1. Изменены стили отдельных элементов
+
+2. Возможность изменять заголовок у Select. Для этого нужно добавить слот `headRender`.
+
+Пример:
+```
+<a-select default-value="lucy" style="width: 120px">
+  <div slot="headRender">
+    <a-button type="link">Select head</a-button>
+  </div>
+  <a-select-option value="jack">
+    Jack
+  </a-select-option>
+  <a-select-option value="lucy">
+    Lucy
+  </a-select-option>
+</a-select>
+```
+
+Также есть возможность оставить стрелку из оригинального компонента, для этого в слоте есть атрибут `arrow`:
+```
+<a-select default-value="lucy">
+  <div slot="headRender"
+       :arrow="true">
+    <a-button type="link"
+              style="padding-right: 24px;">
+      Custom head with arrow
+    </a-button>
+  </div>
+  <a-select-option value="jack">
+    Jack
+  </a-select-option>
+  <a-select-option value="lucy">
+    Lucy
+  </a-select-option>
+</a-select>
+```

--- a/components/select/index.jsx
+++ b/components/select/index.jsx
@@ -232,6 +232,15 @@ const Select = {
         ? cloneElement(menuItemSelectedIcon, { class: `${prefixCls}-selected-icon` })
         : menuItemSelectedIcon)) || <Icon type="check" class={`${prefixCls}-selected-icon`} />;
 
+    let selectHead = null;
+    if (this.$slots.headRender) {
+      selectHead = cloneElement(this.$slots.headRender, {
+        props: {
+          disabled: this.disabled,
+        },
+      });
+    }
+
     const selectProps = {
       props: {
         inputIcon: this.renderSuffixIcon(prefixCls),
@@ -258,6 +267,7 @@ const Select = {
           : filterEmpty(this.$slots.default),
         __propsSymbol__: Symbol(),
         dropdownRender: getComponentFromProp(this, 'dropdownRender', {}, false),
+        selectHead: selectHead,
         getPopupContainer: getPopupContainer || getContextPopupContainer,
       },
       on: getListeners(this),

--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -104,6 +104,7 @@ const Select = {
     autoClearSearchValue: PropTypes.bool.def(true),
     tabIndex: PropTypes.any.def(0),
     dropdownRender: PropTypes.func.def(menu => menu),
+    selectHead: PropTypes.object.def(true),
     // onChange: noop,
     // onFocus: noop,
     // onBlur: noop,
@@ -1577,6 +1578,38 @@ const Select = {
       }
       this.inputBlur(e);
     },
+    renderSelectHead() {
+      const props = this.$props;
+      const multiple = isMultipleOrTags(props);
+      const ctrlNode = this.renderTopControlNode();
+      const prefixCls = props.prefixCls;
+      const realOpen = this.getRealOpenState();
+
+      const selectionProps = {
+        props: {},
+        attrs: {
+          role: 'combobox',
+          'aria-autocomplete': 'list',
+          'aria-haspopup': 'true',
+          'aria-expanded': realOpen,
+          'aria-controls': this.$data._ariaId,
+        },
+        class: `${prefixCls}-selection ${prefixCls}-selection--${multiple ? 'multiple' : 'single'}`,
+        key: 'selection',
+      };
+
+      if (this.selectHead) {
+        return this.selectHead;
+      } else {
+        return (
+          <div {...selectionProps}>
+            {ctrlNode}
+            {this.renderClear()}
+            {this.renderArrow(!!multiple)}
+          </div>
+        );
+      }
+    },
   },
 
   render() {
@@ -1586,7 +1619,6 @@ const Select = {
     const { showArrow = true } = props;
     const state = this.$data;
     const { disabled, prefixCls, loading } = props;
-    const ctrlNode = this.renderTopControlNode();
     const { _open: open, _inputValue: inputValue, _value: value } = this.$data;
     if (open) {
       const filterOptions = this.renderFilterOptions();
@@ -1597,33 +1629,7 @@ const Select = {
     const empty = this._empty;
     const options = this._options || [];
     const { mouseenter = noop, mouseleave = noop, popupScroll = noop } = getListeners(this);
-    const selectionProps = {
-      props: {},
-      attrs: {
-        role: 'combobox',
-        'aria-autocomplete': 'list',
-        'aria-haspopup': 'true',
-        'aria-expanded': realOpen,
-        'aria-controls': this.$data._ariaId,
-      },
-      on: {
-        // click: this.selectionRefClick,
-      },
-      class: `${prefixCls}-selection ${prefixCls}-selection--${multiple ? 'multiple' : 'single'}`,
-      // directives: [
-      //   {
-      //     name: 'ant-ref',
-      //     value: this.saveSelectionRef,
-      //   },
-      // ],
-      key: 'selection',
-    };
-    //if (!isMultipleOrTagsOrCombobox(props)) {
-    // selectionProps.on.keydown = this.onKeyDown;
-    // selectionProps.on.focus = this.selectionRefFocus;
-    // selectionProps.on.blur = this.selectionRefBlur;
-    // selectionProps.attrs.tabIndex = props.disabled ? -1 : props.tabIndex;
-    //}
+
     const rootCls = {
       [prefixCls]: true,
       [`${prefixCls}-open`]: open,
@@ -1698,11 +1704,7 @@ const Select = {
           onClick={this.selectionRefClick}
           onKeydown={isMultipleOrTagsOrCombobox(props) ? noop : this.onKeyDown}
         >
-          <div {...selectionProps}>
-            {ctrlNode}
-            {this.renderClear()}
-            {this.renderArrow(!!multiple)}
-          </div>
+          {this.renderSelectHead()}
         </div>
       </SelectTrigger>
     );

--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -1599,7 +1599,19 @@ const Select = {
       };
 
       if (this.selectHead) {
-        return this.selectHead;
+        const selectHeadAttr = this.selectHead.data.attrs;
+        const arrowEnabled = !!selectHeadAttr.arrow;
+
+        if (arrowEnabled) {
+          return (
+            <div>
+              {this.selectHead}
+              {this.renderArrow(!!multiple)}
+            </div>
+          );
+        } else {
+          return this.selectHead;
+        }
       } else {
         return (
           <div {...selectionProps}>

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -119,35 +119,45 @@
           </a-select-option>
         </a-select>
 
-        <a-select default-value="lucy" style="width: 120px">
-          <div slot="headRender">123</div>
+        <a-select default-value="lucy">
+          <div slot="headRender">
+            <a-button type="link">Custom head</a-button>
+          </div>
           <a-select-option value="jack">
             Jack
           </a-select-option>
           <a-select-option value="lucy">
             Lucy
-          </a-select-option>
-          <a-select-option value="disabled" disabled>
-            Disabled
-          </a-select-option>
-          <a-select-option value="Yiminghe">
-            yiminghe
           </a-select-option>
         </a-select>
 
-        <a-select default-value="lucy" style="width: 120px" disabled>
-          <div slot="headRender">123</div>
+        <a-select default-value="lucy">
+          <div slot="headRender"
+               :arrow="true"
+          >
+            <a-button type="link"
+                      style="padding-right: 24px;"
+            >
+              Custom head with arrow
+            </a-button>
+          </div>
           <a-select-option value="jack">
             Jack
           </a-select-option>
           <a-select-option value="lucy">
             Lucy
           </a-select-option>
-          <a-select-option value="disabled" disabled>
-            Disabled
+        </a-select>
+
+        <a-select default-value="lucy" disabled>
+          <div slot="headRender">
+            <a-button type="link">Disabled custom head</a-button>
+          </div>
+          <a-select-option value="jack">
+            Jack
           </a-select-option>
-          <a-select-option value="Yiminghe">
-            yiminghe
+          <a-select-option value="lucy">
+            Lucy
           </a-select-option>
         </a-select>
 

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -90,6 +90,38 @@
 
       <br/>
       <br/>
+      <h2>Select</h2>
+      <div style="padding: 10px;">
+        <a-select default-value="lucy" style="width: 120px">
+          <a-select-option value="jack">
+            Jack
+          </a-select-option>
+          <a-select-option value="lucy">
+            Lucy
+          </a-select-option>
+          <a-select-option value="disabled" disabled>
+            Disabled
+          </a-select-option>
+          <a-select-option value="Yiminghe">
+            yiminghe
+          </a-select-option>
+        </a-select>
+
+        <a-select default-value="lucy" style="width: 120px" disabled>
+          <a-select-option value="lucy">
+            Lucy
+          </a-select-option>
+        </a-select>
+
+        <a-select default-value="lucy" style="width: 120px" loading>
+          <a-select-option value="lucy">
+            Lucy
+          </a-select-option>
+        </a-select>
+      </div>
+
+      <br/>
+      <br/>
       <h2>Buttons</h2>
       <div style="padding: 10px;">
         <a-button type="primary">Primary</a-button>

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -118,6 +118,39 @@
             Lucy
           </a-select-option>
         </a-select>
+
+        <a-select default-value="lucy" style="width: 120px">
+          <div slot="headRender">123</div>
+          <a-select-option value="jack">
+            Jack
+          </a-select-option>
+          <a-select-option value="lucy">
+            Lucy
+          </a-select-option>
+          <a-select-option value="disabled" disabled>
+            Disabled
+          </a-select-option>
+          <a-select-option value="Yiminghe">
+            yiminghe
+          </a-select-option>
+        </a-select>
+
+        <a-select default-value="lucy" style="width: 120px" disabled>
+          <div slot="headRender">123</div>
+          <a-select-option value="jack">
+            Jack
+          </a-select-option>
+          <a-select-option value="lucy">
+            Lucy
+          </a-select-option>
+          <a-select-option value="disabled" disabled>
+            Disabled
+          </a-select-option>
+          <a-select-option value="Yiminghe">
+            yiminghe
+          </a-select-option>
+        </a-select>
+
       </div>
 
       <br/>

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -298,7 +298,7 @@
               </a-popover>
             </td>
             <td>
-              <a-popover placement="top" visible="true">
+              <a-popover placement="top" :visible="true">
                 <template slot="content">
                   <p>Content</p>
                   <p>Content</p>
@@ -367,7 +367,7 @@
             <td>&nbsp;</td>
             <td>&nbsp;</td>
             <td>
-              <a-popover placement="right" visible="true">
+              <a-popover placement="right" :visible="true">
                 <template slot="content">
                   <p>Content</p>
                   <p>Content</p>
@@ -467,7 +467,7 @@
               </a-tooltip>
             </td>
             <td>
-              <a-tooltip placement="top" visible="true">
+              <a-tooltip placement="top" :visible="true">
                 <template slot="title">
                   <span>Текст подсказки</span>
                 </template>
@@ -507,7 +507,7 @@
           </tr>
           <tr>
             <td>
-              <a-tooltip placement="left" visible="true">
+              <a-tooltip placement="left" :visible="true">
                 <template slot="title">
                   <span>Текст подсказки</span>
                 </template>
@@ -518,7 +518,7 @@
             <td>&nbsp;</td>
             <td>&nbsp;</td>
             <td>
-              <a-tooltip placement="right" visible="true">
+              <a-tooltip placement="right" :visible="true">
                 <template slot="title">
                   <span>Текст подсказки</span>
                 </template>
@@ -558,7 +558,7 @@
               </a-tooltip>
             </td>
             <td>
-              <a-tooltip placement="bottom" visible="true">
+              <a-tooltip placement="bottom" :visible="true">
                 <template slot="title">
                   <span>Текст подсказки</span>
                 </template>


### PR DESCRIPTION
Возможность изменять заголовок у Select. Для этого нужно добавить слот `headRender`.

Пример:
```
<a-select default-value="lucy" style="width: 120px">
  <div slot="headRender">
    <a-button type="link">Select head</a-button>
  </div>
  <a-select-option value="jack">
    Jack
  </a-select-option>
  <a-select-option value="lucy">
    Lucy
  </a-select-option>
</a-select>
```

Также есть возможность оставить стрелку из оригинального компонента, для этого в слоте есть атрибут `arrow`:
```
<a-select default-value="lucy">
  <div slot="headRender"
       :arrow="true">
    <a-button type="link"
              style="padding-right: 24px;">
      Custom head with arrow
    </a-button>
  </div>
  <a-select-option value="jack">
    Jack
  </a-select-option>
  <a-select-option value="lucy">
    Lucy
  </a-select-option>
</a-select>
```