### PR TITLE
Btn group full width

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,14 @@ by Mottor 💪
     </a-tab-pane>
 </a-tabs>
 ```
+
+6. Возможность растягивать компонент a-radio-group по всю ширину родительского элемента. Для этого нужно добавить
+атрибут `:full-width="true"`
+
+```
+<a-radio-group default-value="1" :full-width="true">
+    <a-radio-button value="1">1</a-radio-button>
+    <a-radio-button value="2">test</a-radio-button>
+    <a-radio-button value="3">Very long option.....</a-radio-button>
+</a-radio-group>
+```

--- a/components/radio/Group.jsx
+++ b/components/radio/Group.jsx
@@ -27,6 +27,7 @@ export default {
     disabled: Boolean,
     name: String,
     buttonStyle: PropTypes.string.def('outline'),
+    fullWidth: PropTypes.bool.def(false),
   },
   data() {
     const { value, defaultValue } = this;
@@ -94,6 +95,7 @@ export default {
     const groupPrefixCls = `${prefixCls}-group`;
     const classString = classNames(groupPrefixCls, `${groupPrefixCls}-${buttonStyle}`, {
       [`${groupPrefixCls}-${props.size}`]: props.size,
+      [`${groupPrefixCls}-full-width`]: this.fullWidth,
     });
 
     let children = filterEmpty(this.$slots.default);

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -148,6 +148,10 @@ span.@{radio-prefix-cls} + * {
   padding-left: 8px;
 }
 
+.@{radio-group-prefix-cls}-full-width {
+  display: flex;
+}
+
 .@{radio-prefix-cls}-button-wrapper {
   position: relative;
   display: inline-block;
@@ -176,6 +180,10 @@ span.@{radio-prefix-cls} + * {
     width: 0;
     height: 0;
     margin-left: 0;
+  }
+
+  .@{radio-group-prefix-cls}-full-width & {
+    flex-basis: auto;
   }
 
   .@{radio-group-prefix-cls}-large & {

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -201,6 +201,25 @@
         <a-button type="dashed">Dashed</a-button>
         <a-button type="danger">Danger</a-button>
         <a-button type="link">Link</a-button>
+
+        <br>
+        <br>
+        <h3>Button Group</h3>
+
+        <a-radio-group default-value="1" size="default">
+          <a-radio-button value="1">1</a-radio-button>
+          <a-radio-button value="2">test</a-radio-button>
+          <a-radio-button value="3">Very long option.....</a-radio-button>
+        </a-radio-group>
+
+        <div style="width:500px; border: 1px dashed grey; padding: 4px; display: inline-block; margin-left: 12px;">
+          <a-radio-group default-value="1"
+                         :full-width="true">
+            <a-radio-button value="1">1</a-radio-button>
+            <a-radio-button value="2">test</a-radio-button>
+            <a-radio-button value="3">Very long option.....</a-radio-button>
+          </a-radio-group>
+        </div>
       </div>
 
 


### PR DESCRIPTION
 Возможность растягивать компонент a-radio-group по всю ширину родительского элемента. Для этого нужно добавить атрибут `:full-width="true"`